### PR TITLE
Read splittable LZO effectively in transformer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,10 +43,12 @@ lazy val transformer = project
   .settings(BuildSettings.dynamoDbSettings)
   .settings(
     resolvers ++= Seq(
-      "Sonatype OSS Snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
+      "Sonatype OSS Snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/",
+      "Maven Twitter" at "https://maven.twttr.com/" // Used for Hadoop LZO
     ),
     libraryDependencies ++= Seq(
       Dependencies.hadoop,
+      Dependencies.hadoopLzo,
       Dependencies.spark,
       Dependencies.sparkSql,
       Dependencies.schemaDdl,
@@ -61,6 +63,7 @@ lazy val commonDependencies = Seq(
   Dependencies.analyticsSdk,
   Dependencies.fs2,
   Dependencies.decline,
+  Dependencies.declineEnumeratum,
   Dependencies.s3,
   Dependencies.dynamodb,
   Dependencies.enumeratum,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,7 @@ object Dependencies {
   object V {
     // Java
     val hadoop           = "2.8.5"
+    val hadoopLzo        = "0.4.20"
     val snowflakeJdbc    = "3.11.0"
     val aws              = "1.11.209"
     // Scala
@@ -37,6 +38,7 @@ object Dependencies {
 
   // Java
   val hadoop           = "org.apache.hadoop"     % "hadoop-aws"                    % V.hadoop         % Provided
+  val hadoopLzo        = "com.hadoop.gplcompression"     % "hadoop-lzo"            % V.hadoopLzo      % Provided
   val snowflakeJdbc    = "net.snowflake"         % "snowflake-jdbc"                % V.snowflakeJdbc
   val s3               = "com.amazonaws"         % "aws-java-sdk-s3"               % V.aws
   val dynamodb         = "com.amazonaws"         % "aws-java-sdk-dynamodb"         % V.aws
@@ -48,6 +50,7 @@ object Dependencies {
   val sparkSql         = "org.apache.spark"      %% "spark-sql"                    % V.spark          % Provided
   val fs2              = "co.fs2"                %% "fs2-core"                     % V.fs2
   val decline          = "com.monovore"          %% "decline"                      % V.decline
+  val declineEnumeratum= "com.monovore"          %% "decline-enumeratum"           % V.decline
   val analyticsSdk     = "com.snowplowanalytics" %% "snowplow-scala-analytics-sdk" % V.analyticsSdk
   val enumeratum       = "com.beachape"          %% "enumeratum"                   % V.enumeratum
   val igluClient       = ("com.snowplowanalytics" %% "iglu-scala-client"           % V.igluClient)

--- a/transformer/src/main/scala/com/snowplowanalytics/snowflake/transformer/Main.scala
+++ b/transformer/src/main/scala/com/snowplowanalytics/snowflake/transformer/Main.scala
@@ -38,7 +38,7 @@ object Main extends IOApp {
 
   def run(args: List[String]): IO[ExitCode] = {
     Cli.Transformer.parse(args).value.flatMap {
-      case Right(Cli.Transformer(appConfig, igluClient, inbatch, eventsManifestConfig)) =>
+      case Right(Cli.Transformer(appConfig, igluClient, inbatch, eventsManifestConfig, inputCompressionFormat)) =>
 
         // Always use EMR Role role for manifest-access
         for {
@@ -61,7 +61,9 @@ object Main extends IOApp {
           exitCode <- runFolders match {
             case Right(folders) =>
               val configs = folders.map(S3Config(appConfig.input, appConfig.stageUrl, appConfig.badOutputUrl, _))
-              TransformerJob.run(spark, manifest, appConfig.manifest, configs, eventsManifestConfig, inbatch, atomic).as(ExitCode.Success)
+              TransformerJob.run(spark, manifest, appConfig.manifest, configs, eventsManifestConfig, inbatch, atomic,
+                inputCompressionFormat
+              ).as(ExitCode.Success)
             case Left(error) =>
               die(s"Cannot get list of unprocessed folders\n$error")
           }

--- a/transformer/src/test/scala/com/snowplowanalytics/snowflake/transformer/TransformerJobSpec.scala
+++ b/transformer/src/test/scala/com/snowplowanalytics/snowflake/transformer/TransformerJobSpec.scala
@@ -32,8 +32,8 @@ import cats.syntax.either._
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.Schema
 import com.snowplowanalytics.iglu.schemaddl.jsonschema.circe.implicits._
 import com.snowplowanalytics.iglu.client.Resolver
-
-import com.snowplowanalytics.snowflake.core.{ Cli, idClock }
+import com.snowplowanalytics.snowflake.core.Cli.CompressionFormat
+import com.snowplowanalytics.snowflake.core.{Cli, idClock}
 import com.snowplowanalytics.snowflake.transformer.TransformerJobConfig.FSConfig
 import com.snowplowanalytics.snowplow.eventsmanifest.EventsManifestConfig
 
@@ -238,7 +238,7 @@ trait TransformerJobSpec extends Specification with BeforeAfterAll {
       val badOutput = if (badRowsShouldBeStored) Some(dirs.badRows.toString) else None
       val eventManifestConfig = if (crossBatchDedup) Some(duplicateStorageConfig) else None
       val config = FSConfig(input.toString, dirs.output.toString, badOutput)
-      TransformerJob.process(spark, config, eventManifestConfig, inBatchDedup, atomic)
+      TransformerJob.process(spark, config, eventManifestConfig, inBatchDedup, atomic, Some(CompressionFormat.None))
       deleteRecursively(input)
   }
   override def afterAll(): Unit = {


### PR DESCRIPTION
Reading indexed LZO compressed files from Spark cannot be achieved using
the default `textFile()` because `textFile()` does not understand how to
split the LZO file even when an index is available.

This results in reading an indexed LZO file from the same executor, thus
reducing the job parallelism.

To read effectively indexed LZO, `newAPIHadoopFile()` is used to rely on
the available indexing, and splitting the file multiple partition
automatically.

The compression format of input files is passed as a CLI argument to
control which implementation is used.

This should close #104 